### PR TITLE
Make it clear that initialValues is used as the initial form data, not just for pristine/dirty

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ returned from validation or submission.
 
 #### `initialValues?: Object`
 
-The initial values of your form. These will be used to compare against the
-current values to calculate `pristine` and `dirty`.
+The initial values of your form. These will also be used to compare against
+the current values to calculate `pristine` and `dirty`.
 
 #### `onSubmit: (values: Object, callback: ?(errors: ?Object) => void) => ?Object | Promise<?Object>`
 


### PR DESCRIPTION
I had to check the source code after reading the readme to check that `intialValues` did also do the obvious thing of setting initial values.  The readme made it sound like they were only used for pristine/dirty checks.